### PR TITLE
fix meta tag attributes

### DIFF
--- a/templates/header.php
+++ b/templates/header.php
@@ -7,14 +7,14 @@ header('Content-Type: text/html; charset=utf-8');
   <title class="p-name"><?= $channelName ?> <?= $dateTitle ?></title>
 
   <?php if($permalink): ?>
-  <meta name="description" value="<?= htmlspecialchars($current->nick . ': ' . $current->line) ?>">
+  <meta name="description" content="<?= htmlspecialchars($current->nick . ': ' . $current->line) ?>">
   <meta name="author" content="<?= htmlspecialchars($current->nick) ?>"/>
   <?php endif; ?>
   <?php if(isset($userUrl) && $userUrl): ?>
   <link rel="author" href="<?= htmlspecialchars($userUrl) ?>"/>
   <?php endif; ?>
   <?php if(isset($noindex) && $noindex): ?>
-  <meta name="robots" value="noindex,follow"/>
+  <meta name="robots" content="noindex,follow"/>
   <?php endif; ?>
 
   <script src="/assets/jquery-3.1.0.min.js"></script>


### PR DESCRIPTION
While looking at the timestamp issue, I noticed that some meta tags had `value=""` attributes, not `content=""`
