### PR TITLE
Allow lines to be hidden from display when they are marked as hidden in the log files.

### DIFF
--- a/lib/format.php
+++ b/lib/format.php
@@ -32,6 +32,11 @@ function format_line($channel, $date, $tz, $input, $mf=true) {
   $timestamp = DateTime::createFromFormat('U.u', $input->timestamp);
   $line['timestamp'] = $timestamp->format('Uu');
   $line['type'] = $input->type;
+  $hidden = false;
+  if (substr($line['type'], 0, 7) === 'hidden-') {
+    $hidden = true;
+    $line['type'] = substr($line['type'], 7);
+  }
   if(preg_match('/^\[\[(?<page>.+)\]\](?: (?<type>[!NM]*|delete|restore|upload|moved))? (?<url>[^ ]+) +\* (?<user>[^\*]+) \* (?:\((?<size>[+-]\d+)\))?(?:uploaded|deleted|restored|moved)?(?<comment>.*)/', $line['content'], $match)) {
     $line = format_wiki_line($channel, $line, $match, $mf, $blank_avatar);
     if(isset($line['who']))
@@ -92,7 +97,7 @@ function format_line($channel, $date, $tz, $input, $mf=true) {
   $mf = $mf && !in_array($line['type'], ['join','leave']);
 
 
-  echo '<div id="t' . $line['timestamp'] . '" class="' . ($mf ? 'h-entry' : '') . ' line msg-' . $line['type'] . ' ' . implode(' ', $classes) . '">';
+  echo '<div id="t' . $line['timestamp'] . '" class="' . ($mf ? 'h-entry' : '') . ' line msg-' . $line['type'] . ' ' . implode(' ', $classes) . '"' . ($hidden ? ' hidden' : '') . '>';
 
     echo '<div class="in">';
       echo '<a href="' . $urlInContext . '" class="hash">#</a> ';


### PR DESCRIPTION
As [I have stated](https://chat.indieweb.org/meta/2017-12-17/1513530037035500) I really don’t like hard removing lines from logs. That is counter-intuitive to what logs are supposed to be. But I can see the value in hiding spam from what we publicly display.

I propose non-destructively adding `hidden-` in front of the type parameter of any lines we would like to make disappear.

This change to the output formatter is also non-destructive in that it only hides it using HTML5’s `hidden` attribute. I do this in favour of returning an empty string because this way people can still get the complete logs by running an h-feed parser on the chat.indieweb.org pages.

What do people think?