### PR TITLE
Update #message width to keep from running off right edge of narrow s…

### DIFF
--- a/templates/chat.php
+++ b/templates/chat.php
@@ -56,7 +56,7 @@
 }
 #message {
   font-size: 15px;
-  width: 400px;
+  width: 90vw;
 }
 #irc_notice {
   position: absolute;

--- a/templates/chat.php
+++ b/templates/chat.php
@@ -56,7 +56,8 @@
 }
 #message {
   font-size: 15px;
-  width: 90vw;
+  width: 400px;
+  max-width: 95vw;
 }
 #irc_notice {
   position: absolute;


### PR DESCRIPTION
In indieweb chat, on my small very old iPhone, the input#message element, where you type in messages to submit to chat, is wider than the screen. This makes it difficult to, at times, impossible to see the end of what you're typing, as in iOS you can't even scroll the input field if you can't drag-select all the way to the right edge of it, and that's past the right edge of the screen on my phone. 

By changing the max-width of input#message to 95vw, the input field will always be 95% of the width of the browser window at most, whatever that might be. 

N.B. Using 95vw as the width causes problems at wide widths due to the pop-out channel sidebar taking up a lot of the window's width and pushing the input off the right edge of the screen even though may be very wide because 95vw is so big at those widths. But because 400px is usually under 95vw, the 95vw limit only takes priority when the window is so narrow that it's below the breakpoint where the pop-out sidebar is automatically collapsed, so there's no problem in that case. 