### PR TITLE
Update URL auto linking

### DIFF
--- a/lib/Regex.php
+++ b/lib/Regex.php
@@ -114,7 +114,7 @@ class Regex_Twitter extends Regex
 
 class Regex_URL extends Regex
 {
-    public static $expression = '|(https?:\/\/[^\s]+(?<![\),.]))|';
+    public static $expression = '|(https?:\/\/[^\s]+(?<![\),\.]))|';
     public static $replacement = '<a href="$1" target="_blank">$1</a>';
 
     /**

--- a/lib/Regex.php
+++ b/lib/Regex.php
@@ -114,7 +114,7 @@ class Regex_Twitter extends Regex
 
 class Regex_URL extends Regex
 {
-    public static $expression = '|(https?:\/\/[^\s]+(?<![\),]))|';
+    public static $expression = '|(https?:\/\/[^\s]+(?<![\),.]))|';
     public static $replacement = '<a href="$1" target="_blank">$1</a>';
 
     /**


### PR DESCRIPTION
exclude period at end of URL when autolinking.

Prevents examples like https://chat.indieweb.org/meta/2025-01-16#t1737060633636700 where the period is included in the link, leading to a wiki page that doesn't exist.